### PR TITLE
Feat: setupMocks 함수 분리 및 로컬 백엔드와 분리

### DIFF
--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -10,27 +10,11 @@ import { store } from './store';
 
 export const serverAPI = (path: string) => `${import.meta.env.VITE_API_URL}${path}`;
 
-async function enableMocking(): Promise<void> {
-  if (import.meta.env.MODE !== 'development') {
-    return;
-  }
-
-  const { worker } = await import('../shared/test/browser');
-  await worker.start({
-    onUnhandledRequest: (req) => {
-      const url = new URL(req.url);
-      if (url.pathname.endsWith('.svg')) {
-        return; // .svg 파일 요청을 무시
-      }
-    },
-  });
-}
-
-enableMocking().then(() => {
+(async () => {
   const token = localStorage.getItem('accessToken');
-  if (token) {
-    store.dispatch(storeLogin({ token }));
-  }
+  if (token) store.dispatch(storeLogin({ token }))
+
+  await import('../shared/test/setupMocks').then((module) => module.setupMocks())
 
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <ReactQueryProvider>
@@ -40,4 +24,4 @@ enableMocking().then(() => {
       <Toaster richColors />
     </ReactQueryProvider>
   );
-});
+})()

--- a/src/shared/test/setupMocks.ts
+++ b/src/shared/test/setupMocks.ts
@@ -1,0 +1,17 @@
+export async function setupMocks(): Promise<void> {
+  if (import.meta.env.MODE !== 'development') {
+    return;
+  }
+
+  if (import.meta.env.VITE_USE_MOCK !== 'true') return;
+
+  const { worker } = await import('../test/browser');
+  await worker.start({
+    onUnhandledRequest: (req) => {
+      const url = new URL(req.url);
+      if (url.pathname.endsWith('.svg')) {
+        return; // .svg 파일 요청을 무시
+      }
+    },
+  });
+}


### PR DESCRIPTION
## 💡 작업 내용

- [x] setupMocks 함수 분리
- [x] 테스트 코드 MSW 실행과 로컬 백엔드 서버를 분리

## 💡 자세한 설명

### 테스트 코드 MSW 실행과 로컬 백엔드 서버를 분리

.env 파일에 `VITE_USE_MOCK` 변수를 둬서 값이 true면 MSW를 실행하고
false면 로컬 백엔드 서버를 실행할 수 있도록 분리했습니다.

```ts
export async function setupMocks(): Promise<void> {
  if (import.meta.env.MODE !== 'development') {
    return;
  }

  if (import.meta.env.VITE_USE_MOCK !== 'true') return;

  const { worker } = await import('../test/browser');
  await worker.start({
    onUnhandledRequest: (req) => {
      const url = new URL(req.url);
      if (url.pathname.endsWith('.svg')) {
        return; // .svg 파일 요청을 무시
      }
    },
  });
}

```
## 🚩 후속 작업 (선택)
석원님도 .env 파일 설정하셔서 사용하면 될 듯 합니다.
```.env
// .env 파일
VITE_USE_MOCK=true
```

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #이슈번호
