### PR TITLE
Fix: drag and drop

### DIFF
--- a/src/features/register/lib/useDragAndDrop.ts
+++ b/src/features/register/lib/useDragAndDrop.ts
@@ -1,4 +1,4 @@
-import { DragEndEvent, DragStartEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { DragEndEvent, DragStartEvent, MouseSensor, PointerSensor, TouchSensor, useSensor, useSensors } from '@dnd-kit/core';
 
 import { arrayMove } from '@dnd-kit/sortable';
 import { useState } from 'react';
@@ -6,8 +6,24 @@ import { useState } from 'react';
 export const useDragAndDrop = (state: string[], setState: (state: string[]) => void) => {
   const [activeId, setActiveId] = useState<string | null>(null);
 
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: {
+      distance: 5,
+    },
+  });
+  const touchSensor = useSensor(TouchSensor, {
+    activationConstraint: {
+      distance: 5,
+    },
+  });
+  const pointerSensor = useSensor(PointerSensor, {
+    activationConstraint: {
+      distance: 5,
+    },
+  });
+
   // 센서 정의, PointerSensor는 마우스, 터치, 펜 이벤트를 모두 커버
-  const sensors = useSensors(useSensor(PointerSensor));
+  const sensors = useSensors(mouseSensor, touchSensor, pointerSensor);
 
   const handleDragStart = (event: DragStartEvent) => {
     setActiveId(event.active.id as string);

--- a/src/features/register/ui/ImageUploaderInput.tsx
+++ b/src/features/register/ui/ImageUploaderInput.tsx
@@ -18,7 +18,7 @@ export const ImageUploaderInput = ({ images, setImages }: ImageUploaderProps) =>
 
 
   return (
-    <div className='flex flex-col items-center gap-5 web:flex-row web:h-32'>
+    <div className='flex flex-col items-center gap-5 web:flex-row web:h-32 touch-none'>
       {/* 이미지 추가 버튼 */}
       <AddImageButton handleBoxClick={handleBoxClick} length={images.length} progress={progress} isReading={isReading} />
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] 모바일 호환 drag and drop 개선

## 💡 자세한 설명

- 드래그가 발생하는 영역에 CSS로 `touch-action: none`을 지정해, 브라우저가 스크롤·핀치 줌 등을 먼저 처리하지 못하도록 막는다.
- pointer events를 지원하지 않는 브라우저를 대비하기 위해 터치 이벤트와 마우스 이벤트 추가.

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #이슈번호
