### PR TITLE
fix: LCP 지수 개선

### DIFF
--- a/.github/workflows/integration-main.yml
+++ b/.github/workflows/integration-main.yml
@@ -43,4 +43,3 @@ jobs:
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           VITE_API_URL: http://localhost:8080
-          VITE_USE_MOCK: true

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -33,13 +33,6 @@ async function setupMocks(): Promise<void> {
 
   await setupMocks();
 
-  if (typeof window !== 'undefined') {
-    import('react-scan').then(({ scan }) => {
-      scan({ enabled: true });
-    });
-  }
-
-
   const root = createRoot(document.getElementById('root')!);
   root.render(
     <ReactQueryProvider>

--- a/src/features/details/ui/AuctionDetailsMain.tsx
+++ b/src/features/details/ui/AuctionDetailsMain.tsx
@@ -1,15 +1,14 @@
-import { CustomCarousel } from '@/shared/ui/CustomCarousel';
-import { ProgressiveImage } from '@/shared/ui/ProgressiveImage';
-import { CarouselItem } from '@/shared/ui/carousel';
-import { useGetAuctionDetails } from '../model/useGetAuctionDetails';
-import { AuctionDetailsFooter } from "./AuctionDetailsFooter";
-
 import { Layout } from "@/app/layout/ui/Layout";
 import type { IAuctionDetails } from "@/entities/auction/types/details";
 import ParticipantAmount from '@/shared/assets/icons/my_participation_amount.svg';
 import Participants from '@/shared/assets/icons/participants.svg';
 import ProfileDefaultImage from '@/shared/assets/icons/profile.svg';
+import { CustomCarousel } from '@/shared/ui/CustomCarousel';
+import { ProgressiveImage } from '@/shared/ui/ProgressiveImage';
+import { CarouselItem } from '@/shared/ui/carousel';
 import { formatCurrencyWithWon } from "@/shared/utils/formatCurrencyWithWon";
+import { useGetAuctionDetails } from '../model/useGetAuctionDetails';
+import { AuctionDetailsFooter } from "./AuctionDetailsFooter";
 import { DetailsBasic } from './DetailsBasic';
 import { ProgressBar } from './ProgressBar';
 

--- a/src/features/details/ui/PreAuctionDetailsMain.tsx
+++ b/src/features/details/ui/PreAuctionDetailsMain.tsx
@@ -1,10 +1,3 @@
-import { useDeletePreAuction } from '../model/useDeletePreAuction';
-import { useGetAuctionDetails } from '../model/useGetAuctionDetails';
-
-import { DetailsBasic } from './DetailsBasic';
-import { DetailsOption } from './DetailsOption';
-import { PreAuctionDetailsFooter } from './PreAuctionDetailsFooter';
-
 import { Layout } from '@/app/layout/ui/Layout';
 import type { IPreAuctionDetails } from '@/entities/auction/types/details';
 import BoxEditIcon from '@/shared/assets/icons/in_box_edit_time.svg';
@@ -17,6 +10,11 @@ import { ProgressiveImage } from '@/shared/ui/ProgressiveImage';
 import { CarouselItem } from '@/shared/ui/carousel';
 import { getTimeAgo } from '@/shared/utils/getTimeAgo';
 import { useNavigate } from 'react-router';
+import { useDeletePreAuction } from '../model/useDeletePreAuction';
+import { useGetAuctionDetails } from '../model/useGetAuctionDetails';
+import { DetailsBasic } from './DetailsBasic';
+import { DetailsOption } from './DetailsOption';
+import { PreAuctionDetailsFooter } from './PreAuctionDetailsFooter';
 
 export const PreAuctionDetailsMain = ({ auctionId }: { auctionId: number }) => {
   const navigate = useNavigate();

--- a/src/shared/ui/ProgressiveImage.tsx
+++ b/src/shared/ui/ProgressiveImage.tsx
@@ -16,43 +16,31 @@ export const ProgressiveImage = ({
   loading,
   ...props
 }: ProgressiveImageProps) => {
-  const [highResLoaded, setHighResLoaded] = useState(false);
+  // 현재 표시 중인 src
+  const [currentSrc, setCurrentSrc] = useState(lowResSrc);
+  // 고해상도 이미지 로드 여부
+  const [isHighResLoaded, setIsHighResLoaded] = useState(false);
 
   useEffect(() => {
     const img = new Image();
     img.src = highResSrc;
     img.onload = () => {
-      setHighResLoaded(true);
+      setCurrentSrc(highResSrc);
+      setIsHighResLoaded(true);
     };
   }, [highResSrc]);
 
   return (
-    <div className="relative h-full overflow-hidden">
-      <img
-        src={lowResSrc}
-        style={{
-          opacity: highResLoaded ? 0 : 1,
-          transition: 'opacity 0.7s ease-out',
-          display: 'block'
-        }}
-        loading={loading}
-        {...{ fetchpriority: priority }}
-        {...props}
-      />
-      <img
-        src={highResSrc}
-        alt={alt}
-        style={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          opacity: highResLoaded ? 1 : 0.1,
-          transition: 'opacity 0.7s ease-out'
-        }}
-        loading={loading}
-        {...{ fetchpriority: priority }}
-        {...props}
-      />
-    </div>
+    <img
+      src={currentSrc}
+      alt={alt}
+      style={{
+        transition: 'filter 0.5s ease-out',
+        filter: isHighResLoaded ? 'none' : 'blur(5px)',
+      }}
+      loading={loading}
+      {...{ fetchpriority: priority }}
+      {...props}
+    />
   );
 };

--- a/src/stories/components/product/ProductItem.test.tsx
+++ b/src/stories/components/product/ProductItem.test.tsx
@@ -43,7 +43,7 @@ describe('ProductItem 컴포넌트 테스트', () => {
     expect(productImage).toBeInTheDocument();
     expect(productImage).toHaveAttribute(
       'src',
-      'https://via.placeholder.com/150?h=228'
+      'https://via.placeholder.com/150?h=20'
     );
 
     const auctionName = screen.getByText('테스트 상품');


### PR DESCRIPTION
## 💡 작업 내용

- [x] workflow에서 env 파일의 VITE_USE_MOCK 항목 삭제
- [x] image 개선 통해 LCP 지수 개선

## 💡 자세한 설명

### LCP(Largest Content Paint)란?
LCP 매트릭은 사용자가 페이지로 처음 이동한 시점을 기준으로 뷰포트 내에 있는 가장 큰 이미지 또는 텍스트 블록의 렌더링 시간을 측정한다. 
페이지 로드와 LCP 사이에서는 HTTP 연결, 리다이렉트, TTFB, First Paint, FCP 등 많은 일이 일어난다.
우수한 사용자 환경을 제공하려면 사이트에서 페이지 방문의 75% 이상에 대해 LCP가 2.5초 이하가 되도록 노력해야 한다.

### Lighthouse에서의 LCP 지수
- TTFB(Time To First Byte, TTFB): 서버로부터 HTML 문서 로드를 시작하는 데 걸리는 시간 => 보통 CDN 사용해서 TTFB 개선한다.
- 리소스 로드 지연(Resource Load Delay): 브라우저가 LCP 이미지를 탐색하는 데 걸리는 시간.
- 리소스 로드 시간(Resource Load Time): 브라우저가 LCP 이미지를 다운로드하는 데 걸리는 시간.
- 렌더링 지연(Render Delay): 브라우저가 LCP 이미지 또는 기타 LCP 요소를 표시하는 데 걸리는 시간.

### 문제 발생
이미지 최적화(압축 및 포멧 그리고 워커 사용한 병렬 처리) 이후 3.2초까지 줄였으나, 11초를 넘어가는 문제 발생.
원인은 이미지 로드 속도가 느려 흰 화면이 보이는 문제 발생하여 이를 해결하는 과정에서 발생.

#### 잘못된 접근


처음에는 고해상도 이미지를 불러오는 과정에서 저해상도 이미지를 빨리 불러와 blur와 opacity 효과주어 사용자가 흰 화면을 보는 시간을 줄이고자 했다. 
하지만 이러한 방식은 브라우저가 LCP 대상으로 어떤 이미지를 선택할지가 불명확해진다. 
처음에 로딩되는 저해상도 이미지(lowResSrc)를 브라우저가 **Largest Content** 로 간주해 LCP 시점을 먼저 찍었다가, 이후 고해상도 이미지(highResSrc)가 로드되면 최종 이미지를 다른 요소로 인식할 수 있기 때문에 새로 LCP가 갱신될 수도 있다. 
또한 저해상도 이미지 리소스를 추가 요청하는 것이기 때문에 추가적인 로드 지연이 발생할 수 있다.
그리고 opacity의 fade-in, fade-out 효과 때문에 최종 상태(완전한 불투명 상태)가 나타날 때까지 LCP가 지연될 가능성이 있다.

#### 개선 방안
두 개의 `<img>` 태그가 아닌, 하나의 `<img>` 태그 내에서 `src`를 교체하는 방법을 사용했다. 즉 초기에 저해상도 이미지(lowResSrc)를 보여주고, 고해상도 이미지(highResSrc) 로드가 완료되면, 동일한 <img>의 src를 고해상도 이미지로 변경한다.
이 경우 브라우저가 “**Largest Content** 가 이 이미지”라는 것을 초기부터 인식할 수 있어 불필요하게 LCP가 재측정되거나 연기되는 상황을 줄일 수 있다.
또한 opacity 대신 blur만 사용해서 LCP가 지연되는 것을 미연에 방지한다.

##### 이전 LCP 지수
<img width="270" alt="opacity LCP 로드지연" src="https://github.com/user-attachments/assets/f683763c-b251-43a6-9af9-cd3f7628cb46" />

##### 이후 LCP 지수
이전과 비교했을 때 LCP는 약 75퍼 개선되었으며, FCP 또한 약 18퍼 개선되었다.
이전 3.2초 보다 더 개선된 모습인데, 이는 코드 스플리팅 작업의 영향인 듯 하다.
<img width="280" alt="LCP 개선 이후" src="https://github.com/user-attachments/assets/19aaacd5-d030-4d9e-b1d2-b54f207ca0c0" />

## 📗 참고 자료 (선택)
[최대 콘텐츠 렌더링 시간(LCP)](https://web.dev/articles/lcp?hl=ko)
[최대 콘텐츠 렌더링 시간 최적화](https://web.dev/articles/optimize-lcp?hl=ko#1_eliminate_resource_load_delay)
[(번역) 렌더링 지연을 개선해 LCP 점수 향상하기](https://velog.io/@superlipbalm/lcp-render-delay)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #이슈번호
