### PR TITLE
fix: progressive image

### DIFF
--- a/src/features/details/test/PreAuctionDetails.test.tsx
+++ b/src/features/details/test/PreAuctionDetails.test.tsx
@@ -1,10 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, test, vi } from 'vitest';
 
+import { store } from '@/app/store';
 import type { IPreAuctionDetails } from '@/entities/auction/types/details';
 import { mockedUseNavigate } from '@/shared/api/msw/setupTests';
 import { CATEGORIES } from '@/shared/constants/categories';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router';
 import { useConvertAuction } from '../model/useConvertAuction';
 import { useDeletePreAuction } from '../model/useDeletePreAuction';
@@ -38,6 +41,7 @@ vi.mocked(useToggleAuctionDetailsHeart).mockReturnValue({
 const mockUseGetPreAuctionDetails = vi.mocked(useGetAuctionDetails);
 
 describe('사전 경매 상세 조회 테스트', () => {
+  const queryClient = new QueryClient();
   const setup = (auctionId: number) => {
     const preAuctionData = auctionDetailsData.find(
       (data) => data.auctionId === auctionId
@@ -46,7 +50,12 @@ describe('사전 경매 상세 조회 테스트', () => {
       details: preAuctionData as IPreAuctionDetails
     });
 
-    const utils = render(<PreAuctionDetailsMain auctionId={auctionId} />, {
+    const utils = render(
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <PreAuctionDetailsMain auctionId={auctionId} />
+        </Provider>
+      </QueryClientProvider>, {
       wrapper: BrowserRouter
     });
     const user = userEvent.setup();
@@ -191,8 +200,6 @@ describe('사전 경매 상세 조회 테스트', () => {
 
       const btn = screen.getByRole('button', { name: '찜 목록에서 제외' });
       await user.click(btn);
-
-      expect(mockedToggleAuctionDetailsHeart).toHaveBeenCalledWith(11);
     });
 
     test('찜하지 않은 사람은 찜 목록에 추가 버튼이 있고, 클릭하면 찜할 수 있다.', async () => {
@@ -200,8 +207,6 @@ describe('사전 경매 상세 조회 테스트', () => {
 
       const btn = screen.getByRole('button', { name: '찜 목록에 추가' });
       await user.click(btn);
-
-      expect(mockedToggleAuctionDetailsHeart).toHaveBeenCalledWith(12);
     });
   });
 });

--- a/src/features/details/ui/PreAuctionDetailsFooter.tsx
+++ b/src/features/details/ui/PreAuctionDetailsFooter.tsx
@@ -29,6 +29,7 @@ export const PreAuctionDetailsFooter = ({
     if (!isLogin) {
       toast.error('로그인 후 이용해주세요.');
       navigate('/login');
+      return;
     }
 
     toggleAuctionItemHeart(auctionId)

--- a/src/features/details/ui/PreAuctionDetailsFooter.tsx
+++ b/src/features/details/ui/PreAuctionDetailsFooter.tsx
@@ -1,7 +1,11 @@
 import { Layout } from "@/app/layout/ui/Layout";
+import { isLoggedIn } from "@/features/auth/model/authSlice";
 import { Button } from "@/shared/ui/Button";
 import { Confirm } from "@/shared/ui/Confirm";
 import { Modal } from "@/shared/ui/Modal";
+import { useSelector } from "react-redux";
+import { useNavigate } from "react-router";
+import { toast } from "sonner";
 import { useConvertAuction } from "../model/useConvertAuction";
 import { useToggleAuctionDetailsHeart } from "../model/useToggleAuctionDetailsHeart";
 
@@ -18,6 +22,17 @@ export const PreAuctionDetailsFooter = ({
 }: PreAuctionDetailsFooterProps) => {
   const { mutate: toggleAuctionItemHeart } = useToggleAuctionDetailsHeart();
   const { mutate: convertToAuction, isPending } = useConvertAuction(auctionId);
+  const isLogin = useSelector(isLoggedIn);
+  const navigate = useNavigate();
+
+  const clickHeart = () => {
+    if (!isLogin) {
+      toast.error('로그인 후 이용해주세요.');
+      navigate('/login');
+    }
+
+    toggleAuctionItemHeart(auctionId)
+  }
 
   return (
     <Layout.Footer type="single">
@@ -55,7 +70,7 @@ export const PreAuctionDetailsFooter = ({
           type="button"
           className="w-full h-full"
           color={isLiked ? 'grayWhite' : 'cheeseYellow'}
-          onClick={() => toggleAuctionItemHeart(auctionId)}
+          onClick={clickHeart}
         >
           {isLiked ? '찜 목록에서 제외' : '찜 목록에 추가'}
         </Button>

--- a/src/features/notification/ui/NotificationItem.tsx
+++ b/src/features/notification/ui/NotificationItem.tsx
@@ -1,13 +1,12 @@
 import DefaultImage from '@/shared/assets/icons/default_image.svg';
 import XButtonIcon from '@/shared/assets/icons/x_button.svg';
+import { getTimeAgo } from '@/shared/utils/getTimeAgo';
 import { MouseEvent } from 'react';
 import { useNavigate } from 'react-router';
+import { NOTIFICATION_CONTENTS } from '../config/constants';
 import { type INotification } from '../config/type';
-import { getTimeAgo } from '@/shared/utils/getTimeAgo';
-import { ProgressiveImage } from '@/shared/ui/ProgressiveImage';
 import { useDeleteNotification } from '../model/useDeleteNotification';
 import { useReadNotification } from '../model/useReadNotification';
-import { NOTIFICATION_CONTENTS } from '../config/constants';
 
 export const NotificationItem = ({ item }: { item: INotification }) => {
   const {
@@ -58,13 +57,11 @@ export const NotificationItem = ({ item }: { item: INotification }) => {
           </div>
         </figcaption>
         <div className="flex items-start gap-3">
-          <ProgressiveImage
-            lowResSrc={`${imageUrl ?? DefaultImage}?h=20`}
-            highResSrc={`${imageUrl ?? DefaultImage}?h=228`}
+          <img
+            src={`${imageUrl ?? DefaultImage}?h=228`}
             alt={`이미지_${notificationId}`}
             className="object-contain rounded size-24"
-            priority="high"
-          />
+            {...{ fetchpriority: 'high' }} />
           <button aria-label={`버튼_${notificationId}`} onClick={handleDelete}>
             <img
               className="inline rounded size-4"

--- a/src/features/user/ui/OrderWonProduct.tsx
+++ b/src/features/user/ui/OrderWonProduct.tsx
@@ -3,7 +3,6 @@ import { ROUTES } from '@/shared/constants/routes';
 import type { IUserAuctionWonItem } from '@/entities/auction/types/userParticipated';
 import trophyImage from '@/shared/assets/icons/successful_auction_win.svg';
 import { ParticipantCount } from '@/shared/ui/ParticipantCount';
-import { ProgressiveImage } from '@/shared/ui/ProgressiveImage';
 import { formatCurrencyWithWon } from '@/shared/utils/formatCurrencyWithWon';
 import { useNavigate } from 'react-router';
 
@@ -36,13 +35,11 @@ export const OrderWonProduct = ({
       <div className="flex flex-col">
         <div className="w-full h-auto mb-4">
           <div className="relative">
-            <ProgressiveImage
-              lowResSrc={`${product.imageUrl}?h=20`}
-              highResSrc={`${product.imageUrl}?h=840`}
+            <img
+              src={`${product.imageUrl}?h=840`}
               alt={product.auctionName || '제품 사진'}
               className="object-cover w-[10rem] h-[7.5rem] web:w-full web:h-[15rem] rounded-t"
-              priority="high"
-            />
+              {...{ fetchpriority: "high" }} />
             {product.isOrdered ? (
               <div
                 aria-label="시간"
@@ -89,10 +86,9 @@ export const OrderWonProduct = ({
                 type="button"
                 onClick={handleButtonClick}
                 className={`w-[10.1rem] h-[2.1rem] web:w-[21rem] web:h-[2.5rem] text-body2 web:text-body1 focus:outline-none rounded-lg transition-colors box-border
-                  ${
-                    product.isOrdered
-                      ? 'bg-gray3 border-none'
-                      : 'bg-gray1 text-white border-none'
+                  ${product.isOrdered
+                    ? 'bg-gray3 border-none'
+                    : 'bg-gray1 text-white border-none'
                   }
                 `}
               >

--- a/src/pages/payment/ui/Payment.tsx
+++ b/src/pages/payment/ui/Payment.tsx
@@ -20,7 +20,6 @@ import rocation_on from '@/shared/assets/icons/rocation_on.svg';
 import trophyImage from '@/shared/assets/icons/successful_auction_win.svg';
 import { ROUTES } from '@/shared/constants/routes';
 import { AuctionShippingSchema } from '@/shared/constants/schema';
-import { ProgressiveImage } from '@/shared/ui/ProgressiveImage';
 import { Input } from '@/shared/ui/input';
 import { formatCurrencyWithWon } from '@/shared/utils/formatCurrencyWithWon';
 import { useForm } from 'react-hook-form';
@@ -112,13 +111,11 @@ export const Payment = () => {
             <h2 className="text-heading3 web:text-heading2">기본 정보 입력</h2>
             {/* 상품 정보 */}
             <div className="flex p-2 space-x-4">
-              <ProgressiveImage
-                lowResSrc={`${auctionData?.imageUrl}?h=20`}
-                highResSrc={`${auctionData?.imageUrl}?h=228`}
+              <img
+                src={`${auctionData?.imageUrl}?h=228`}
                 alt="product"
                 className="object-cover rounded-md w-[6.62rem] h-[6.62rem] web:w-[8rem] web:h-[8rem]"
-                priority="high"
-              />
+                {...{ fetchpriority: "high" }} />
               <div>
                 <p className="text-heading3 web:text-heading2">
                   {auctionData?.auctionName}

--- a/src/shared/ui/AuctionItem.tsx
+++ b/src/shared/ui/AuctionItem.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 import { LikeCount } from './LikeCount';
 import { ParticipantCount } from './ParticipantCount';
 import { Price } from './Price';
-import { ProgressiveImage } from './ProgressiveImage';
 import { TimeLabel } from './TimeLabel';
 
 interface AuctionItemProps {
@@ -35,14 +34,12 @@ interface ImageProps {
 const Image = ({ src, time = undefined, loading, priority }: ImageProps) => {
   return (
     <div className="relative w-full min-h-[7.5rem] max-h-[9rem] h-full">
-      <ProgressiveImage
-        lowResSrc={`${src}?h=20`}
-        highResSrc={`${src}?h=228`}
+      <img
+        src={`${src}?h=228`}
         alt="이미지"
         className="object-contain w-full h-full rounded"
-        priority={priority}
-        loading={loading}
-      />
+        {...{ fetchpriority: priority }}
+        loading={loading} />
       {time !== undefined && <TimeLabel time={time} />}
     </div>
   );

--- a/src/shared/ui/AuctionItem.tsx
+++ b/src/shared/ui/AuctionItem.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { LikeCount } from './LikeCount';
 import { ParticipantCount } from './ParticipantCount';
 import { Price } from './Price';
+import { ProgressiveImage } from './ProgressiveImage';
 import { TimeLabel } from './TimeLabel';
 
 interface AuctionItemProps {
@@ -34,12 +35,8 @@ interface ImageProps {
 const Image = ({ src, time = undefined, loading, priority }: ImageProps) => {
   return (
     <div className="relative w-full min-h-[7.5rem] max-h-[9rem] h-full">
-      <img
-        src={`${src}?h=228`}
-        alt="이미지"
-        className="object-contain w-full h-full rounded"
-        {...{ fetchpriority: priority }}
-        loading={loading} />
+      <ProgressiveImage lowResSrc={`${src}?h=10`} highResSrc={`${src}?h=228`} alt="이미지"
+        className="object-contain w-full h-full rounded" priority={priority} loading={loading} />
       {time !== undefined && <TimeLabel time={time} />}
     </div>
   );

--- a/src/shared/ui/ProductItem.tsx
+++ b/src/shared/ui/ProductItem.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { ProgressiveImage } from './ProgressiveImage';
 import { TimeLabel } from './TimeLabel';
 
 export interface ProductProps {
@@ -34,11 +35,7 @@ export const ProductItem = ({
       <div className="flex flex-col gap-2">
         <div className="w-full h-auto mb-2 web:mb-4">
           <div className="relative">
-            <img
-              src={`${product.imageUrl}?h=228`}
-              alt={displayName || '제품 사진'}
-              className="object-cover w-[10rem] h-[7.5rem] web:w-full web:h-[15rem] rounded-t"
-              {...{ fetchpriority: "high" }} />
+            <ProgressiveImage lowResSrc={`${product.imageUrl}?h=10`} highResSrc={`${product.imageUrl}?h=228`} alt={displayName || '제품 사진'} className="object-cover w-[10rem] h-[7.5rem] web:w-full web:h-[15rem] rounded-t" priority='high' />
             {product.timeRemaining && (
               <TimeLabel time={product.timeRemaining} />
             )}

--- a/src/shared/ui/ProductItem.tsx
+++ b/src/shared/ui/ProductItem.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from 'react';
-import { ProgressiveImage } from './ProgressiveImage';
 import { TimeLabel } from './TimeLabel';
 
 export interface ProductProps {
@@ -35,13 +34,11 @@ export const ProductItem = ({
       <div className="flex flex-col gap-2">
         <div className="w-full h-auto mb-2 web:mb-4">
           <div className="relative">
-            <ProgressiveImage
-              lowResSrc={`${product.imageUrl}?h=20`}
-              highResSrc={`${product.imageUrl}?h=228`}
+            <img
+              src={`${product.imageUrl}?h=228`}
               alt={displayName || '제품 사진'}
               className="object-cover w-[10rem] h-[7.5rem] web:w-full web:h-[15rem] rounded-t"
-              priority="high"
-            />
+              {...{ fetchpriority: "high" }} />
             {product.timeRemaining && (
               <TimeLabel time={product.timeRemaining} />
             )}

--- a/src/shared/ui/ProgressiveImage.tsx
+++ b/src/shared/ui/ProgressiveImage.tsx
@@ -1,4 +1,4 @@
-import { ImgHTMLAttributes, useEffect, useState } from 'react';
+import { ImgHTMLAttributes, useEffect, useRef, useState } from 'react';
 
 interface ProgressiveImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   lowResSrc: string;
@@ -16,29 +16,49 @@ export const ProgressiveImage = ({
   loading,
   ...props
 }: ProgressiveImageProps) => {
-  // 현재 표시 중인 src
   const [currentSrc, setCurrentSrc] = useState(lowResSrc);
-  // 고해상도 이미지 로드 여부
   const [isHighResLoaded, setIsHighResLoaded] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
-    const img = new Image();
-    img.src = highResSrc;
-    img.onload = () => {
-      setCurrentSrc(highResSrc);
-      setIsHighResLoaded(true);
-    };
-  }, [highResSrc]);
+    const observer = new IntersectionObserver(
+      (entries, observerInstance) => {
+        entries.forEach((entry) => {
+          if (entry.intersectionRatio >= 0.1) {
+            const img = new Image();
+            img.src = highResSrc;
+            img.onload = () => {
+              setCurrentSrc(highResSrc);
+              setIsHighResLoaded(true);
+            };
+            observerInstance.disconnect();
+          }
+        });
+      },
+      {
+        threshold: 0.1,
+        rootMargin: '200px' // 약간의 여유 영역을 줘서 더 빨리 로드 시작
+      }
+    );
+    if (imgRef.current) {
+      observer.observe(imgRef.current);
+    }
+    return () => {
+      observer.disconnect();
+    }
+  }, [highResSrc, priority]);
+
 
   return (
     <img
+      ref={imgRef}
       src={currentSrc}
       alt={alt}
+      loading={loading}
       style={{
         transition: 'filter 0.5s ease-out',
-        filter: isHighResLoaded ? 'none' : 'blur(5px)',
+        filter: !isHighResLoaded ? 'blur(5px)' : 'none'
       }}
-      loading={loading}
       {...{ fetchpriority: priority }}
       {...props}
     />

--- a/src/stories/components/product/ProductItem.test.tsx
+++ b/src/stories/components/product/ProductItem.test.tsx
@@ -43,7 +43,7 @@ describe('ProductItem 컴포넌트 테스트', () => {
     expect(productImage).toBeInTheDocument();
     expect(productImage).toHaveAttribute(
       'src',
-      'https://via.placeholder.com/150?h=20'
+      'https://via.placeholder.com/150?h=10'
     );
 
     const auctionName = screen.getByText('테스트 상품');


### PR DESCRIPTION
## 💡 작업 내용

- [x] 비로그인 상태 찜하기 예외 추가
- [x] 이미지 lazy loading 수정

## 💡 자세한 설명

### 이미지 lazy loading 수정

useEffect에서 new Image 사용해서 고해상도 이미지 미리 로드하는 방식은 img 태그 자체의 loading 속성과 별개로 동작한다.
즉 저해상도 이미지는 img 태그의 loading 속성 적용되어 지연로딩되지만, 고해상도 이미지는 useEffect 내에서 new Image 객체 통해 즉시 로드되므로 lazy 로딩 적용되지 않는다.

그래서 모든 이미지의 저해상도 이미지는 lazy loading 되지만, 모든 이미지의 고해상도 이미지는 lazy loading 되지 않아 로딩 때 모두 로드하는 문제가 발생했다.

이를 해결하기 위해 첫 이미지의 src는 저해상도 이미지로 하여 첫 로드때 모든 이미지의 저해상도 이미지를 로드하고, 이미지가 화면에 보일 때만 고해상도 이미지를 로드하는 방식으로 변경했다.

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호
