### PR TITLE
feat: deploy cache 전략 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,16 +64,38 @@ jobs:
       # 9. S3로 배포
       - name: Deploy to S3
         run: |
-          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET_NAME }} --delete --exact-timestamps
+          aws s3 sync ./dist s3://${{ secrets.S3_BUCKET_NAME }} --delete --exact-timestamps  --exclude "assets/font/*" --exclude "favicon.svg" --exclude "robots.txt"
           echo "Deployment to S3 and CloudFront completed successfully!"
 
-      # 10. CloudFront 캐시 무효화
+      # 10. vendor 청크 업로드 (Cache-Control 헤더 적용)
+      - name: Deploy vendor chunks with Cache-Control
+        run: |
+          aws s3 cp ./dist s3://${{ secrets.S3_BUCKET_NAME }} --recursive \
+            --exclude "*" \
+            --include "react-vendor*.js" \
+            --include "axios-vendor*.js" \
+            --include "tough-cookie-vendor*.js" \
+            --include "zod-vendor*.js" \
+            --metadata-directive REPLACE \
+            --cache-control "max-age=31536000, public, immutable"
+
+      # 11. 폰트 파일 업로드 (Cache-Control 헤더 적용)
+      - name: Deploy font files with Cache-Control
+        run: |
+          aws s3 cp ./dist/assets/font s3://${{ secrets.S3_BUCKET_NAME }}/assets/font --recursive --metadata-directive REPLACE --cache-control "max-age=31536000, public, immutable"
+
+      # 12. favicon.svg & robots.txt 업로드 (Cache-Control 헤더 적용)
+      - name: Deploy favicon and robots.txt with Cache-Control
+        run: |
+          aws s3 cp ./dist/favicon.svg s3://${{ secrets.S3_BUCKET_NAME }}/favicon.svg --metadata-directive REPLACE --cache-control "max-age=31536000, public, immutable"
+          aws s3 cp ./dist/robots.txt s3://${{ secrets.S3_BUCKET_NAME }}/robots.txt --metadata-directive REPLACE --cache-control "max-age=31536000, public, immutable"
+    
+      # 13. CloudFront 캐시 무효화
       - name: Invalidate CloudFront Cache
         run: |
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
-          echo "CloudFront Cache Invalidated!"
 
-      # 11. 배포 상태 업데이트 (성공)
+      # 14. 배포 상태 업데이트 (성공)
       - name: Update deployment status (success)
         if: success()
         uses: chrnorm/deployment-status@v2
@@ -83,7 +105,7 @@ jobs:
           state: 'success'
           deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
-      # 12. 배포 상태 업데이트 (실패)
+      # 15. 배포 상태 업데이트 (실패)
       - name: Update deployment status (failure)
         if: failure()
         uses: chrnorm/deployment-status@v2


### PR DESCRIPTION
## 💡 작업 내용

- [x] 변하지 않는 파일은 캐시하는 전략 추가

## 💡 자세한 설명

Vite는 빌드 시 파일 이름에 해시를 추가하여 파일 내용이 변경되지 않으면 동일한 이름을 유지한다.  예를 들어, Pretendard-Medium.woff2 파일은 빌드 후 Pretendard-Medium-Dq5e4H0E.woff2로 변경된다. 이로 인해 브라우저는 이미 다운로드한 파일을 재사용할 수 있다.

브라우저는 기본적으로 캐시 기능을 제공하지만 서버나 CDN에서 HTTP 캐싱 헤더를 명시적으로 설정해야 브라우저가 언제까지 캐시를 유지할지 정확하게 알 수 있다.

즉 Vite의 해시 기반 파일 네이밍과 HTTP 캐싱 헤더 설정이 함께 작동하면 브라우저는 불필요한 네트워크 요청 없이 안정적으로 파일을 캐시할 수 있다.

폰트 파일, favicon, robots.txt, React 관련 라이브러리 등 변경 가능성이 낮은 파일은 배포 시 S3의 캐시 설정을 통해 장기간 캐시함으로써 불필요한 네트워크 요청을 줄여 로딩 시간을 줄일 수 있다.

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #이슈번호
