### PR TITLE
fix: innerHeight를 visualViewport로 변경

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,21 +4,18 @@ import { router } from './router';
 
 const App = () => {
   useEffect(() => {
-    const setVh = () => {
-      // innerHeight에 기반하여 1vh를 px로 계산
-      const vh = window.innerHeight * 0.01;
-
-      // HTML 루트에 CSS 변수 세팅
-      document.documentElement.style.setProperty('--vh', `${vh}px`);
+    const updateHeight = () => {
+      const { height } = window.visualViewport ?? {};
+      if (height) {
+        document.documentElement.style.setProperty('--vh', `${height * 0.01}px`);
+      }
     };
 
-    setVh();
-
-    // 윈도우 사이즈 바뀔 때마다 변수 갱신
-    window.addEventListener('resize', setVh);
+    window.visualViewport?.addEventListener('resize', updateHeight);
+    updateHeight();
 
     return () => {
-      window.removeEventListener('resize', setVh);
+      window.visualViewport?.removeEventListener('resize', updateHeight);
     };
   }, []);
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] innerHeight를 visualViewport로 변경

## 💡 자세한 설명

- window.innerHeight : 브라우저가 이론적 뷰포트로 계산한 값. 모바일 환경에서 주소창이 나타났다/숨겨져도 바로 그 변화를 제대로 반영하지 못하거나, 또는 전체 뷰포트 높이를 그대로 반환해 레이아웃이 의도와 다르게 튀는 상황이 생길 수 있음.
- window.visualViewport.height : 실제 사용자에게 보이는 영역(브라우저 UI가 차지하는 부분 제외)의 높이. 모바일에서 주소창·탭 바가 가려진 영역은 제외되므로, 현재 실시간으로 보이는 뷰포트 정보를 얻을 수 있음.

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #이슈번호
